### PR TITLE
Update all GitHub Actions to latest stable versions (June 2024)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3
    
   analyze_js:
     name: Analyze Javascript
@@ -64,14 +64,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,12 @@ jobs:
     build_test:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
             # Disabling shallow clone is recommended for improving relevancy of reporting
             fetch-depth: 0
         - name: Setup .NET Core
-          uses: actions/setup-dotnet@v1
+          uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '9.0.x'
         - name: Install dotnet tool
@@ -42,7 +42,7 @@ jobs:
           run: dotnet test --no-restore --no-build --configuration Release --logger trx --verbosity minimal RecipeApp/Website.sln --filter Category!=Integration --collect:"XPlat Code Coverage"
           
         - name: XUnit Test Report
-          uses: dorny/test-reporter@v1
+          uses: dorny/test-reporter@v1.8.0
           if: success() || failure()    # run this step even if previous step failed
           with:
             name: XUnit Results
@@ -53,7 +53,7 @@ jobs:
             token: ${{ github.token }}
           
         - name: ReportGenerator
-          uses: danielpalme/ReportGenerator-GitHub-Action@4.8.9
+          uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
           with:
             # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
             reports: "**/coverage.cobertura.xml"
@@ -84,13 +84,13 @@ jobs:
             # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings
             #customSettings: # optional, default is 
         - name: Upload coverage report artifact
-          uses: actions/upload-artifact@v2.2.3
+          uses: actions/upload-artifact@v4
           with:
             name: CoverageReport # Artifact name        
             path: coveragereport/index.htm # Directory containing files to upload
             
         - name: Report Code Coverage
-          uses: romeovs/lcov-reporter-action@v0.2.11
+          uses: romeovs/lcov-reporter-action@v0.3.1
           with:
             lcov-file: coveragereport/lcov.info
             github-token: ${{ github.token }}

--- a/.github/workflows/pr_deploy.yml
+++ b/.github/workflows/pr_deploy.yml
@@ -13,9 +13,9 @@ jobs:
       if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy_pr') }}
       runs-on: ubuntu-latest
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
           - name: Docker Login
-            uses: docker/login-action@v1.6.0
+            uses: docker/login-action@v3
             with:
                 username: ${{ secrets.DOCKERHUB_USERNAME }}
                 # Password or personal access token used to log against the Docker registry
@@ -36,17 +36,17 @@ jobs:
       needs: pkg_dev
       steps:
           - name: Azure authentication
-            uses: azure/login@v1.4.1
+            uses: azure/login@v2
             with:
                 creds: ${{ secrets.AZURE_CREDENTIALS }}
           - name: Deploy UI to Azure
-            uses: azure/webapps-deploy@v2
+            uses: azure/webapps-deploy@v3
             with:
                app-name: 'recipe-ui'
                slot-name: 'qa'
                images: 'index.docker.io/queenofcode/recipe_website:dev'
           - name: Deploy API to Azure
-            uses: azure/webapps-deploy@v2
+            uses: azure/webapps-deploy@v3
             with:
                app-name: 'recipe-dataapi'
                slot-name: 'qa'
@@ -56,12 +56,12 @@ jobs:
       if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy_pr') }}
       needs: deploy_dev
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
             # Disabling shallow clone is recommended for improving relevancy of reporting
             fetch-depth: 1
         - name: Setup .NET Core
-          uses: actions/setup-dotnet@v1
+          uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '9.0.x'
         - name: Install dependencies
@@ -74,7 +74,7 @@ jobs:
              RECIPE-INTERNAL-AUTH: ${{ secrets.RECIPE_INTERNAL_AUTH }}
           run: dotnet test --no-restore --no-build --configuration Release --verbosity normal RecipeApp/Website.sln --filter Category=Integration --logger trx
         - name: XUnit Test Report
-          uses: dorny/test-reporter@v1
+          uses: dorny/test-reporter@v1.8.0
           if: success() || failure()    # run this step even if previous step failed
           with:
             name: XUnit Results

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -11,9 +11,9 @@ jobs:
     ship_it:
       runs-on: ubuntu-latest
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
           - name: Docker Login
-            uses: docker/login-action@v1.6.0
+            uses: docker/login-action@v3
             with:
                 username: ${{ secrets.DOCKERHUB_USERNAME }}
                 # Password or personal access token used to log against the Docker registry
@@ -28,16 +28,16 @@ jobs:
                 TAG: latest
             run: docker-compose -f RecipeApp/docker-compose.yml push
           - name: Azure authentication
-            uses: azure/login@v1
+            uses: azure/login@v2
             with:
                 creds: ${{ secrets.AZURE_CREDENTIALS }}
           - name: Deploy UI to Azure
-            uses: azure/webapps-deploy@v2
+            uses: azure/webapps-deploy@v3
             with:
                app-name: 'recipe-ui'
                images: 'index.docker.io/queenofcode/recipe_website:latest'
           - name: Deploy API to Azure
-            uses: azure/webapps-deploy@v2
+            uses: azure/webapps-deploy@v3
             with:
                app-name: 'recipe-dataapi'
                images: 'index.docker.io/queenofcode/recipeapi:latest'
@@ -45,12 +45,12 @@ jobs:
       runs-on: ubuntu-latest
       needs: ship_it
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
             # Disabling shallow clone is recommended for improving relevancy of reporting
             fetch-depth: 0
         - name: Setup .NET Core
-          uses: actions/setup-dotnet@v1
+          uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '9.0.x'
         - name: Install dependencies

--- a/.github/workflows/sonarscanner.yml
+++ b/.github/workflows/sonarscanner.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Sonarscanner for dotnet
       uses: Secbyte/dotnet-sonarscanner@v2.2


### PR DESCRIPTION
This PR updates all GitHub Actions in `.github/workflows` to their latest stable versions as of June 2024. No logic or structure was changed—only action versions were updated for improved security and support.

- actions/checkout, setup-dotnet, docker/login, azure/login, azure/webapps-deploy, dorny/test-reporter, danielpalme/ReportGenerator-GitHub-Action, upload-artifact, romeovs/lcov-reporter-action, and codeql actions are now on their latest stable versions.
- actions/first-interaction remains on v1 (no v2 exists).

Please review and merge to keep workflows up to date!