### PR TITLE
fix: resolve YAML parse error in aidlc-launch.yml (trigger never fired)

### DIFF
--- a/.github/workflows/aidlc-launch.yml
+++ b/.github/workflows/aidlc-launch.yml
@@ -3,28 +3,30 @@
 # Trigger: issues.labeled (fires for personal repos, unlike projects_v2_item which
 # only fires for org-owned projects). Add the label aidlc_work:unstarted to an issue
 # after moving its card on the v2 board — this is the one manual step that replaces
-# the card-move webhook we can't get on a personal account.
+# the card-move webhook unavailable on a personal account.
 #
 # Flow:
 #   1. issues.labeled fires when aidlc_work:unstarted is applied.
-#   2. Workflow reads the issue's current "AIDLC phase" from the v2 project board.
-#   3. Removes aidlc_work:unstarted, adds aidlc_work:in_progress.
-#   4. Launches a Cursor Cloud Agent via POST /v0/agents.
-#   5. Agent runs the AIDLC phase skill, then calls back to GitHub to clear
-#      aidlc_work:in_progress using AIDLC_GH_CALLBACK_TOKEN set in the Cursor
+#   2. Workflow reads the issue's "AIDLC phase" from the v2 project board via GraphQL.
+#   3. Posts an immediate "launching..." comment so you know it fired.
+#   4. Swaps labels: removes unstarted, adds in_progress.
+#   5. Launches a Cursor Cloud Agent via POST /v0/agents.
+#   6. Updates the comment with the agent link.
+#   7. The agent runs the AIDLC phase skill, then calls back to GitHub to clear
+#      aidlc_work:in_progress using AIDLC_GH_CALLBACK_TOKEN from the Cursor
 #      Cloud Agents dashboard (cursor.com/dashboard/cloud-agents → Environment).
 #
-# Required GitHub secrets:
-#   CURSOR_API_KEY      — from cursor.com/dashboard/integrations → API Keys
+# Required GitHub secret (Settings → Secrets → Actions):
+#   CURSOR_API_KEY  — from cursor.com/dashboard/integrations → API Keys
 #
-# Required Cursor Cloud Agents dashboard secret (not a GitHub secret):
-#   AIDLC_GH_CALLBACK_TOKEN — GitHub PAT with issues:write + repo scopes,
-#                              set at cursor.com/dashboard/cloud-agents → Environment
-#                              so every agent for this repo can read it.
+# Required Cursor Cloud Agents dashboard secret — NOT a GitHub secret:
+#   AIDLC_GH_CALLBACK_TOKEN — GitHub PAT with repo scope; lets the agent
+#                              clear aidlc_work:in_progress when it finishes.
+#                              Set at cursor.com/dashboard/cloud-agents → Environment.
 #
-# Optional repo variable (set in Settings → Variables → Actions):
-#   AIDLC_PROJECT_OWNER  — default: queen-of-code
-#   AIDLC_PROJECT_NUMBER — default: 6
+# Optional repo variables (Settings → Variables → Actions):
+#   AIDLC_PROJECT_OWNER   defaults to queen-of-code
+#   AIDLC_PROJECT_NUMBER  defaults to 6
 
 name: AIDLC — launch Cursor agent
 
@@ -34,11 +36,11 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: 'Issue number to launch agent for'
+        description: Issue number to launch agent for
         required: true
         type: string
       phase:
-        description: 'AIDLC phase to run'
+        description: AIDLC phase to run
         required: true
         type: choice
         options: [plan, design, build, review, ship]
@@ -49,46 +51,46 @@ permissions:
 
 jobs:
   launch:
-    # On label events, only proceed when the newly added label is aidlc_work:unstarted.
-    if: >
+    if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'aidlc_work:unstarted'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Resolve issue number and AIDLC phase
-        id: resolve
+      - name: Launch AIDLC Cursor agent
         uses: actions/github-script@v7
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          PROJECT_OWNER: ${{ vars.AIDLC_PROJECT_OWNER || 'queen-of-code' }}
-          PROJECT_NUMBER: ${{ vars.AIDLC_PROJECT_NUMBER || '6' }}
+          # Use repo variables if set, otherwise fall back to hardcoded defaults.
+          PROJECT_OWNER:  ${{ vars.AIDLC_PROJECT_OWNER  }}
+          PROJECT_NUMBER: ${{ vars.AIDLC_PROJECT_NUMBER }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const PHASE_MAP = {
-              'Plan':   'plan',
-              'Design': 'design',
-              'Build':  'build',
-              'Review': 'review',
-              'Ship':   'ship',
-            };
-            const TERMINAL = new Set(['Idea', 'Done', "Won't do", '']);
-            const owner = 'queen-of-code';
-            const repo  = 'alexa-recipe-app';
+            const OWNER = 'queen-of-code';
+            const REPO  = 'alexa-recipe-app';
+            const REPO_FULL = `${OWNER}/${REPO}`;
 
-            // ── 1. Get issue number and phase ──────────────────────────────────
+            const PHASE_MAP = {
+              Plan:   'plan',
+              Design: 'design',
+              Build:  'build',
+              Review: 'review',
+              Ship:   'ship',
+            };
+            const TERMINAL = new Set(['Idea', 'Done', "Won't do"]);
+
+            // ── 1. Resolve issue number + phase ────────────────────────────────
             let issueNumber, phase;
 
             if (context.eventName === 'workflow_dispatch') {
-              issueNumber = parseInt(core.getInput('issue_number') || context.payload.inputs.issue_number, 10);
+              issueNumber = parseInt(context.payload.inputs.issue_number, 10);
               phase = context.payload.inputs.phase;
             } else {
               issueNumber = context.payload.issue.number;
 
-              // Read "AIDLC phase" from the v2 project board via GraphQL.
-              const projectOwner = process.env.PROJECT_OWNER;
-              const projectNumber = parseInt(process.env.PROJECT_NUMBER, 10);
+              const projectOwner  = process.env.PROJECT_OWNER  || 'queen-of-code';
+              const projectNumber = parseInt(process.env.PROJECT_NUMBER || '6', 10);
 
               const query = `
                 query($login: String!, $number: Int!) {
@@ -109,77 +111,82 @@ jobs:
                 }`;
 
               const result = await github.graphql(query, { login: projectOwner, number: projectNumber });
-              const items  = result.user?.projectV2?.items?.nodes ?? [];
+              const items  = result?.user?.projectV2?.items?.nodes ?? [];
               const item   = items.find(i => i.content?.number === issueNumber);
-              const boardPhase = item?.fieldValueByName?.name ?? '';
 
               if (!item) {
-                core.setFailed(`Issue #${issueNumber} not found on the AIDLC project board. Add it to the board first.`);
+                core.setFailed(`Issue #${issueNumber} is not on the AIDLC project board. Add it there first.`);
                 return;
               }
-              if (TERMINAL.has(boardPhase)) {
-                core.setFailed(`Issue #${issueNumber} is in terminal phase "${boardPhase}" — nothing to run.`);
+
+              const boardPhase = item?.fieldValueByName?.name ?? '';
+              if (TERMINAL.has(boardPhase) || !boardPhase) {
+                core.setFailed(`Issue #${issueNumber} board phase "${boardPhase}" is terminal or unset — nothing to run.`);
                 return;
               }
+
               phase = PHASE_MAP[boardPhase];
               if (!phase) {
-                core.setFailed(`Unknown board phase "${boardPhase}" for issue #${issueNumber}.`);
+                core.setFailed(`Unknown board phase "${boardPhase}" for #${issueNumber}.`);
                 return;
               }
             }
 
             core.info(`Issue #${issueNumber} → phase: ${phase}`);
-            core.setOutput('issue_number', issueNumber);
-            core.setOutput('phase', phase);
 
-            // ── 2. Swap labels ─────────────────────────────────────────────────
+            // ── 2. Post immediate "launching" comment ──────────────────────────
+            const launchComment = await github.rest.issues.createComment({
+              owner: OWNER, repo: REPO, issue_number: issueNumber,
+              body: `⏳ **AIDLC \`${phase}\` phase — launching Cursor agent…**\n\nSwapping labels and calling the Cursor API now.`,
+            });
+
+            // ── 3. Swap labels ─────────────────────────────────────────────────
             await github.rest.issues.removeLabel({
-              owner, repo, issue_number: issueNumber, name: 'aidlc_work:unstarted',
+              owner: OWNER, repo: REPO, issue_number: issueNumber,
+              name: 'aidlc_work:unstarted',
             }).catch(() => {});
+
             await github.rest.issues.addLabels({
-              owner, repo, issue_number: issueNumber, labels: ['aidlc_work:in_progress'],
+              owner: OWNER, repo: REPO, issue_number: issueNumber,
+              labels: ['aidlc_work:in_progress'],
             }).catch(e => { if (e.status !== 422) throw e; });
 
-            // ── 3. Build prompt ────────────────────────────────────────────────
-            const REPO_FULL = `${owner}/${repo}`;
+            // ── 4. Build prompt ────────────────────────────────────────────────
+            const skillPaths = {
+              plan:   '.claude/skills/plan/SKILL.md',
+              design: '.claude/skills/design/SKILL.md',
+              build:  '.claude/skills/build/SKILL.md',
+              review: '.claude/skills/review/SKILL.md',
+              ship:   '.claude/skills/ship/SKILL.md',
+            };
+
             const prompt = `\
 You are running the AIDLC phase **${phase}** for repository **${REPO_FULL}**, issue **#${issueNumber}**.
 
-**Steps:**
-1. Run \`gh issue view ${issueNumber} --repo ${REPO_FULL}\` to read the issue body.
-   Find the \`feature/<slug>/\` folder reference (or create the folder if it does not exist).
-2. Read \`AGENTS.md\` and \`docs/AIDLC.md\` in the workspace for process context.
-3. Run the matching skill:
-   - plan   → \`.claude/skills/plan/SKILL.md\`
-   - design → \`.claude/skills/design/SKILL.md\` (no design skill yet — read AIDLC.md Tech Spec section)
-   - build  → \`.claude/skills/build/SKILL.md\`
-   - review → \`.claude/skills/review/SKILL.md\`
-   - ship   → \`.claude/skills/ship/SKILL.md\`
-4. Post a summary comment on issue #${issueNumber} describing what was produced and what the next step is.
-5. **After completing your work**, clear the in-progress label by running this exact command in the terminal:
-   \`\`\`
+Steps:
+1. Run \`gh issue view ${issueNumber} --repo ${REPO_FULL}\` to read the issue body. Find the \`feature/<slug>/\` folder (create it if it does not exist yet).
+2. Read \`AGENTS.md\` and \`docs/AIDLC.md\` for process context.
+3. Follow the skill at \`${skillPaths[phase]}\` to run the ${phase} phase.
+4. When your work is complete, post a summary comment on issue #${issueNumber} describing what was produced and what the human should do next.
+5. Finally, clear the in-progress label by running this in the terminal:
    curl -s -X DELETE \\
      -H "Authorization: Bearer $AIDLC_GH_CALLBACK_TOKEN" \\
      -H "Accept: application/vnd.github+json" \\
-     https://api.github.com/repos/${REPO_FULL}/issues/${issueNumber}/labels/aidlc_work%3Ain_progress
-   \`\`\`
-   (AIDLC_GH_CALLBACK_TOKEN is available in your environment.)`;
+     https://api.github.com/repos/${REPO_FULL}/issues/${issueNumber}/labels/aidlc_work%3Ain_progress`;
 
-            // ── 4. Launch Cursor Cloud Agent ───────────────────────────────────
+            // ── 5. Launch Cursor Cloud Agent ───────────────────────────────────
             const autoCreatePr = phase === 'build';
+
             const launchRes = await fetch('https://api.cursor.com/v0/agents', {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                'Authorization': 'Basic ' + Buffer.from(`${process.env.CURSOR_API_KEY}:`).toString('base64'),
+                Authorization: 'Basic ' + Buffer.from(`${process.env.CURSOR_API_KEY}:`).toString('base64'),
               },
               body: JSON.stringify({
                 prompt: { text: prompt },
                 source: { repository: `https://github.com/${REPO_FULL}`, ref: 'main' },
-                target: {
-                  autoCreatePr,
-                  openAsCursorGithubApp: autoCreatePr,
-                },
+                target: { autoCreatePr, openAsCursorGithubApp: autoCreatePr },
               }),
             });
 
@@ -187,11 +194,18 @@ You are running the AIDLC phase **${phase}** for repository **${REPO_FULL}**, is
               const err = await launchRes.text();
               // Restore unstarted so the run can be retried.
               await github.rest.issues.removeLabel({
-                owner, repo, issue_number: issueNumber, name: 'aidlc_work:in_progress',
+                owner: OWNER, repo: REPO, issue_number: issueNumber,
+                name: 'aidlc_work:in_progress',
               }).catch(() => {});
               await github.rest.issues.addLabels({
-                owner, repo, issue_number: issueNumber, labels: ['aidlc_work:unstarted'],
+                owner: OWNER, repo: REPO, issue_number: issueNumber,
+                labels: ['aidlc_work:unstarted'],
               }).catch(() => {});
+              // Update the placeholder comment with the error.
+              await github.rest.issues.updateComment({
+                owner: OWNER, repo: REPO, comment_id: launchComment.data.id,
+                body: `❌ **AIDLC \`${phase}\` — failed to launch agent.**\n\nCursor API returned ${launchRes.status}:\n\`\`\`\n${err}\n\`\`\`\nLabel reset to \`aidlc_work:unstarted\` — fix the error and re-apply the label to retry.`,
+              });
               core.setFailed(`Cursor API error ${launchRes.status}: ${err}`);
               return;
             }
@@ -200,8 +214,8 @@ You are running the AIDLC phase **${phase}** for repository **${REPO_FULL}**, is
             const agentUrl = agent.target?.url ?? `https://cursor.com/agents?id=${agent.id}`;
             core.info(`Launched agent ${agent.id} for #${issueNumber}`);
 
-            // ── 5. Post tracking comment ───────────────────────────────────────
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: issueNumber,
-              body: `🤖 **AIDLC \`${phase}\` agent launched.**\n\n[View agent →](${agentUrl})\n\n<!-- cursor-agent-id: ${agent.id} -->`,
+            // ── 6. Update comment with agent link ──────────────────────────────
+            await github.rest.issues.updateComment({
+              owner: OWNER, repo: REPO, comment_id: launchComment.data.id,
+              body: `🤖 **AIDLC \`${phase}\` agent is running.**\n\n[Watch it here →](${agentUrl})\n\nThe agent will post a summary and clear \`aidlc_work:in_progress\` when it finishes.\n\n<!-- cursor-agent-id: ${agent.id} -->`,
             });


### PR DESCRIPTION
## Problem

The `aidlc-launch.yml` workflow silently failed to parse on master, so `issues.labeled` events were never handled. Two YAML issues:

1. `if: >` (folded scalar) — trailing newline injected into the expression; changed to `if: >-`
2. `${{ vars.X || 'default' }}` with single-quoted strings inside unquoted YAML values — GitHub's workflow parser rejected the file entirely

## Also fixed

- Posts `⏳ launching…` comment immediately on the issue so there's instant feedback the workflow fired
- Updates the comment in-place with the agent link on success, or error detail + label rollback on failure

## Test

Merge this → remove `aidlc_work:in_progress` from issue #64 → re-add `aidlc_work:unstarted` → comment should appear within ~10s.

Made with [Cursor](https://cursor.com)