### PR TITLE
fix: scope greetings workflow to opened events only

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,10 @@
 name: Greetings
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
   greeting:


### PR DESCRIPTION
## Summary
- Restricts the greetings workflow `on:` trigger to `types: [opened]` for both `pull_request` and `issues` events
- Prevents the workflow from firing on label add/remove and other event subtypes

## Test plan
- [ ] Add a label to an existing issue — workflow should NOT trigger
- [ ] Remove a label from an existing issue — workflow should NOT trigger
- [ ] Open a new issue — workflow SHOULD trigger and post the greeting comment
- [ ] Open a new PR — workflow SHOULD trigger and post the greeting comment

Made with [Cursor](https://cursor.com)