### PR TITLE
docs(ship): AIDLC validate + learn for #67 (recipe completed photo)

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,32 @@
+# Project memory (agents)
+
+Quick context for AI assistants working in this repository. **Canonical process:** [docs/AIDLC.md](docs/AIDLC.md).
+
+**Last updated:** 2026-04-28
+
+---
+
+## Architecture overview
+
+- **RecipeApp/** — .NET API (`RecipeAPI`), shared **Core** models, **frontend** React SPA (Vite), Docker Compose for local multi-service runs.
+- **Data:** Recipe CRUD uses **Firestore** (see `RecipeApp/specs/architecture.md`); auth via **Firebase Auth** JWTs to the API.
+- **ADR index:** [adr/](adr/) — start at numbered ADRs for durable decisions.
+
+---
+
+## Implemented features
+
+### [#67](https://github.com/queen-of-code/alexa-recipe-app/issues/67) — Optional completed-dish recipe photo
+
+- **Status:** Shipped (merged PR [#74](https://github.com/queen-of-code/alexa-recipe-app/pull/74)).
+- **Feature folder:** [feature/recipe-completed-photo/](feature/recipe-completed-photo/)
+- **What:** Optional JPEG/PNG/WebP upload on **create/edit** in the web app; thumbnail on recipe list; image on detail. Recipe documents carry `completedImageUrl`; bytes live in **Firebase Storage** under per-user paths. `POST /api/values/{userId}` returns **201** with the saved recipe including **`recipeId`** so the client can upload after first save.
+- **ADR:** [adr/0001-recipe-completed-photo-firebase-storage.md](adr/0001-recipe-completed-photo-firebase-storage.md)
+- **Validate / learn:** [feature/recipe-completed-photo/validate-scorecard.md](feature/recipe-completed-photo/validate-scorecard.md), [feature/recipe-completed-photo/learn-notes.md](feature/recipe-completed-photo/learn-notes.md)
+
+---
+
+## Conventions
+
+- Open PRs against **`master`** (not `main`).
+- AI-DLC skills live under **`.claude/skills`** (symlink to `.claude/deps/ai-dlc` submodule).

--- a/adr/0001-recipe-completed-photo-firebase-storage.md
+++ b/adr/0001-recipe-completed-photo-firebase-storage.md
@@ -1,0 +1,53 @@
+# ADR-0001: Completed-dish recipe photos — Firestore + Firebase Storage
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-04-28 |
+| **Deciders** | Feature owner / engineering (tutorial repo) |
+| **Related** | [feature/recipe-completed-photo/product-spec.md](../feature/recipe-completed-photo/product-spec.md), [feature/recipe-completed-photo/tech-spec.md](../feature/recipe-completed-photo/tech-spec.md), [queen-of-code/alexa-recipe-app#67](https://github.com/queen-of-code/alexa-recipe-app/issues/67), PR [#74](https://github.com/queen-of-code/alexa-recipe-app/pull/74) |
+
+---
+
+## Context
+
+Users need an optional **photo of the finished dish** on a recipe. The app already stores recipe text in **Firestore** and authenticates with **Firebase Auth**. We needed a place for binary image bytes, tenant isolation per user, and a stable reference on the recipe document for list and detail views.
+
+## Decision
+
+Store **metadata on the recipe** (`completedImageUrl` on the Firestore `Recipe` / API `RecipeModel`) and store **file bytes in Firebase Storage** under `users/{firebaseUid}/recipes/{recipeId}/completed.{ext}`. The web client uploads via the Storage SDK; the API validates that any stored URL/path belongs to the authenticated user. **Create recipe** must return the server-assigned **`recipeId` in the JSON body** (HTTP **201**) so the client can upload to a deterministic path after the first save.
+
+## Options considered
+
+| Option | Summary | Why not chosen |
+|--------|---------|----------------|
+| A | Base64 image embedded in Firestore / API JSON | Inflates documents; worse for list payloads and quotas; awkward for large files. |
+| B | External blob store not integrated with Firebase (e.g. raw GCS without Firebase rules) | More bespoke IAM and wiring; Firebase Storage + rules align with existing Auth. |
+| C | Only client-local or session storage | Does not meet “see the same photo later” across devices/sessions. |
+
+## Consequences
+
+### Positive
+
+- Small Firestore documents; images served via Storage URLs.
+- Storage security rules can enforce per-user paths alongside existing JWT checks in RecipeAPI.
+- One object per recipe path keeps abuse bounded when combined with size/type rules.
+
+### Negative / trade-offs
+
+- **Operational:** `storage.rules` must be deployed with the app; emulators (Storage + Auth) needed for faithful local integration tests.
+- **Orphans:** If upload fails after recipe create, or delete fails, orphaned objects are acceptable at tutorial tier; cleanup on successful recipe delete is attempted.
+
+### Neutral / follow-ups
+
+- Client-side image compression is a possible future improvement (not required for v1).
+
+## Compliance & verification
+
+- **API:** `CompletedImageMetadata` unit tests enforce user ownership of paths/URLs; controller tests cover `POST` **201** + `recipeId` in body.
+- **Review:** Security/Tech Spec dimensions on PR #74; Storage rules in repo for deployment verification.
+
+## References
+
+- [Firebase Storage documentation](https://firebase.google.com/docs/storage)
+- Tech Spec: [feature/recipe-completed-photo/tech-spec.md](../feature/recipe-completed-photo/tech-spec.md)

--- a/feature/recipe-completed-photo/learn-notes.md
+++ b/feature/recipe-completed-photo/learn-notes.md
@@ -1,0 +1,21 @@
+# Learn — `recipe-completed-photo`
+
+> AIDLC Learn (ship). See [docs/AIDLC.md](../../docs/AIDLC.md) — Phase 6 Learn.
+
+## ADRs added or updated
+
+- [adr/0001-recipe-completed-photo-firebase-storage.md](../../adr/0001-recipe-completed-photo-firebase-storage.md) — Firestore metadata + Firebase Storage for completed-dish images; `POST` returns body with `recipeId`.
+
+## Documentation updates
+
+- This file, [validate-scorecard.md](./validate-scorecard.md), and [PROJECT.md](../../PROJECT.md) (repo memory for agents).
+- Tech Spec retrospective appended in [tech-spec.md](./tech-spec.md).
+
+## Tech Spec retrospective (plan vs actual)
+
+See **§ Retrospective (ship)** at the bottom of [tech-spec.md](./tech-spec.md).
+
+## Process friction notes
+
+- **Integration tests** need Auth emulator (and related stack) running locally; `dotnet test` without docker/emulators fails integration projects — expected; rely on CI for full suite.
+- **Issue #67** was already **closed** when this ship run executed; `aidlc_work:in_progress` remained and was cleared via automation callback after completion.

--- a/feature/recipe-completed-photo/product-spec.md
+++ b/feature/recipe-completed-photo/product-spec.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | **Feature** | Optional photo of the completed dish on a recipe |
-| **Status** | Draft — awaiting product approval |
+| **Status** | Shipped — validate/scorecard in [validate-scorecard.md](./validate-scorecard.md) |
 | **Tracker** | [queen-of-code/alexa-recipe-app#67](https://github.com/queen-of-code/alexa-recipe-app/issues/67) |
 | **AIDLC feature folder** | `feature/recipe-completed-photo/` |
 

--- a/feature/recipe-completed-photo/tech-spec.md
+++ b/feature/recipe-completed-photo/tech-spec.md
@@ -156,3 +156,27 @@ Traceable to Product Spec success criteria:
 ## Human approval
 
 - [ ] Engineering approved before Build
+
+---
+
+## Retrospective (ship)
+
+Completed with merge of [PR #74](https://github.com/queen-of-code/alexa-recipe-app/pull/74) (2026-04-28).
+
+**Aligned with plan**
+
+- Firestore field **`completedImageUrl`**, Firebase Storage path layout, Storage rules, web-only UX (create/edit/list/detail), POST returns **201** with body including **`recipeId`** (`ValuesApiController.Post`), limits (5 MiB; JPEG/PNG/WebP).
+
+**Differed or tightened in implementation**
+
+- **`completedImageUrl`** holds the Firebase download URL (and paths are parsed for validation/deletion), matching the illustrative JSON in this spec.
+- **Recipe delete:** attempts Storage object removal when metadata maps to an object path (non-emulator); failures logged — as anticipated for orphan tolerance.
+- **CI / dev:** Firebase Storage emulator (9199) and docker-compose/`firebase.json` wiring landed during Build so integration tests and local dev stay aligned.
+
+**Testing**
+
+- Strong unit coverage on metadata + controller POST behavior; frontend tests cover create-with-photo flow. Replace/remove paths rely on code review for this tutorial tier; add tests if regressions appear.
+
+**Process**
+
+- Review flagged advisory items (e.g. manual Validate/E2E); scorecard in `validate-scorecard.md` documents evidence boundaries.

--- a/feature/recipe-completed-photo/validate-scorecard.md
+++ b/feature/recipe-completed-photo/validate-scorecard.md
@@ -1,0 +1,31 @@
+# Validate — Scorecard — `recipe-completed-photo`
+
+> AIDLC Validate (ship). See [docs/AIDLC.md](../../docs/AIDLC.md) — Phase 6.
+
+## Product Spec link
+
+- [feature/recipe-completed-photo/product-spec.md](./product-spec.md) (issue [queen-of-code/alexa-recipe-app#67](https://github.com/queen-of-code/alexa-recipe-app/issues/67))
+
+## Shipped implementation
+
+- **PR (merged):** [queen-of-code/alexa-recipe-app#74](https://github.com/queen-of-code/alexa-recipe-app/pull/74) — merge `23d264576dd2d1ca3c8a2bea35f37a2b76a640c4` (2026-04-28).
+
+## Success criteria checklist
+
+| # | Criterion (from Product Spec) | Pass / Fail | Evidence |
+|---|------------------------------|-------------|----------|
+| 1 | **Create:** signed-in user can save a new recipe **with** optional completed-dish photo and see the same photo later. | **Pass** | `RecipeForm.jsx` create path: `createRecipe` → `uploadCompletedRecipePhoto` → `updateRecipe` with `completedImageUrl`. Frontend test: `RecipeForm.test.jsx` “after create with image, uploads then PUTs completedImageUrl”. List/detail: `RecipeList.jsx`, `RecipeDetail.jsx` render `completedImageUrl` when set. |
+| 2 | **Update:** add / replace / remove photo; empty state after remove. | **Pass** | `RecipeForm.jsx` edit: `removePhoto` clears metadata and deletes storage; `photoDraft` with existing URL triggers replace (delete old, upload new). (Automated tests cover create+upload path; replace/remove covered by implementation review — extend tests if you want full branch coverage.) |
+| 3 | **Privacy / ownership:** user never sees another user’s image on their recipe views. | **Pass** | API: JWT `userId` match (`ValuesApiController`). Metadata validation: `CompletedImageMetadataTests.cs` rejects other-user paths/URLs. Storage layout `users/{uid}/recipes/{recipeId}/…` + rules (per Tech Spec / PR). |
+| 4 | **Optional:** save without photo still works. | **Pass** | Form submit works with no file; `RecipeForm` only uploads when `photoDraft` set. Existing flows unchanged when field omitted. |
+
+## Overall
+
+- **Score:** **100%** (4/4 criteria pass — default AIDLC threshold 90%).
+- **Evidence note:** This agent run validated against **code + unit/frontend tests**. **Integration tests** and **hosted multi-user browser validation** were not executed here (integration requires Firebase emulators; CI was reported green on PR #74). Treat human spot-check in staging/production as optional reinforcement per risk.
+
+- **Human sign-off:** Pending product/engineering per your gates — artifacts are ready for approval.
+
+## If failing — proposed return phase
+
+- N/A at current assessment.


### PR DESCRIPTION
## Summary

AIDLC **Validate + Learn** artifacts for [issue #67](https://github.com/queen-of-code/alexa-recipe-app/issues/67) after merge of [PR #74](https://github.com/queen-of-code/alexa-recipe-app/pull/74).

## Changes

- `feature/recipe-completed-photo/validate-scorecard.md` — Scorecard vs Product Spec (100% at 90% gate).
- `feature/recipe-completed-photo/learn-notes.md`
- `adr/0001-recipe-completed-photo-firebase-storage.md`
- `PROJECT.md`
- Product/Tech spec status + retrospective.

Refs #67