### PR TITLE
Fix fresh-clone local dev and bump AI-DLC v1.0.0

### DIFF
--- a/.github/workflows/aidlc-board-label-sync.yml
+++ b/.github/workflows/aidlc-board-label-sync.yml
@@ -1,0 +1,146 @@
+# Event-driven helpers for aidlc_work:unstarted (Projects v2, personal-account boards).
+#
+# GitHub does NOT offer `on: projects_v2_item` in Actions ([see gh-aw discussion](https://github.com/github/gh-aw/issues/25336)).
+# Webhooks for `projects_v2_item` are organization-projects only ([docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item)).
+# So repo Actions cannot subscribe to board edits directly — but they CAN run when something else dispatches here.
+#
+# Triggers:
+#   - workflow_dispatch — human or script passes issue_number after a board move (or probe after move).
+#   - repository_dispatch (type apply_aidlc_unstarted_if_actionable) — call from automation with { "issue_number": N }.
+
+name: AIDLC apply unstarted label (phase-driven)
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number linked on the AIDLC Projects v2 board (after you move/update its phase)
+        required: true
+        type: string
+
+  repository_dispatch:
+    types: [apply_aidlc_unstarted_if_actionable]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read AIDLC phase → maybe apply aidlc_work:unstarted
+        uses: actions/github-script@v7
+        env:
+          PROJECT_OWNER:     ${{ vars.AIDLC_PROJECT_OWNER }}
+          PROJECT_NUMBER:    ${{ vars.AIDLC_PROJECT_NUMBER }}
+          AIDLC_PROJECT_PAT: ${{ secrets.AIDLC_PROJECT_PAT }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const OWNER = context.repo.owner;
+            const REPO = context.repo.repo;
+
+            /** Must match single-select names on board field "AIDLC phase". */
+            const actionable = new Set(['Plan', 'Design', 'Build', 'Review', 'Ship']);
+
+            let issueNumber = null;
+            if (context.eventName === 'workflow_dispatch') {
+              issueNumber = parseInt(context.payload.inputs.issue_number, 10);
+            } else {
+              issueNumber = parseInt(context.payload.client_payload.issue_number, 10);
+            }
+            if (!issueNumber || issueNumber < 1) {
+              core.setFailed('Invalid issue_number');
+              return;
+            }
+
+            const projectOwner =
+              (context.payload.client_payload && context.payload.client_payload.project_owner &&
+                String(context.payload.client_payload.project_owner).trim()) ||
+              process.env.PROJECT_OWNER ||
+              OWNER;
+            const pn =
+              context.payload.client_payload && context.payload.client_payload.project_number;
+            const projectNumber =
+              (pn !== undefined && pn !== '') ? parseInt(pn, 10) : NaN;
+            const pnFinal = Number.isFinite(projectNumber)
+              ? projectNumber
+              : parseInt(process.env.PROJECT_NUMBER || '6', 10);
+            const pat = process.env.AIDLC_PROJECT_PAT;
+            if (!pat) {
+              core.setFailed(
+                'Missing secret AIDLC_PROJECT_PAT (GraphQL for Projects v2; same PAT as aidlc-agent-launch).'
+              );
+              return;
+            }
+
+            const gql = async (query, variables) => {
+              const res = await fetch('https://api.github.com/graphql', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${pat}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ query, variables }),
+              });
+              const json = await res.json();
+              if (json.errors) throw new Error(JSON.stringify(json.errors));
+              return json.data;
+            };
+
+            let item = null;
+            let cursor = null;
+            while (!item) {
+              const data = await gql(
+                `
+                query($login: String!, $number: Int!, $cursor: String) {
+                  user(login: $login) {
+                    projectV2(number: $number) {
+                      items(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          content { ... on Issue { number } }
+                          fieldValueByName(name: "AIDLC phase") {
+                            ... on ProjectV2ItemFieldSingleSelectValue { name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { login: projectOwner, number: pnFinal, cursor }
+              );
+              const conn = data?.user?.projectV2?.items;
+              const nodes = conn?.nodes ?? [];
+              for (const n of nodes) {
+                if (n.content?.number === issueNumber) {
+                  item = n;
+                  break;
+                }
+              }
+              if (item || !conn?.pageInfo?.hasNextPage) break;
+              cursor = conn.pageInfo.endCursor;
+            }
+            if (!item) {
+              core.setFailed(`Issue #${issueNumber} not found on project #${pnFinal} for ${projectOwner}`);
+              return;
+            }
+
+            const phase = item.fieldValueByName?.name?.trim?.() ?? '';
+            if (!actionable.has(phase)) {
+              core.info(`Phase "${phase}" is not automated — no aidlc_work:unstarted (issue #${issueNumber})`);
+              return;
+            }
+
+            await github.rest.issues.removeLabel({
+              owner: OWNER,
+              repo: REPO,
+              issue_number: issueNumber,
+              name: 'aidlc_work:in_progress',
+            }).catch(() => {});
+            await github.rest.issues.addLabels({
+              owner: OWNER,
+              repo: REPO,
+              issue_number: issueNumber,
+              labels: ['aidlc_work:unstarted'],
+            }).catch(e => {
+              if (e.status !== 422) throw e;
+            });
+            core.info(`aidlc_work:unstarted applied to #${issueNumber} (${phase}).`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ These **orchestrate** AIDLC phases and **pull in** **library** skills (`architec
 | **Work item for a Feature** | GitHub issue on `queen-of-code/alexa-recipe-app`; URL pattern `github.com/queen-of-code/alexa-recipe-app/issues/NNN` |
 | **Phase signal** | "AIDLC phase" single-select field on [project board #6](https://github.com/users/queen-of-code/projects/6); label `aidlc_work:unstarted` is the automation trigger; `aidlc_work:in_progress` means an agent run is active |
 | **Parent ↔ `feature/<slug>/`** | Issue body includes `AIDLC feature folder: feature/<kebab-slug>/` |
-| **Automation entry points** | [`.github/workflows/aidlc-launch.yml`](.github/workflows/aidlc-launch.yml) — triggered by `issues.labeled` (`aidlc_work:unstarted`); reads AIDLC phase from v2 board, launches Cursor Cloud Agent, tracks via issue comment |
+| **Automation entry points** | **[`aidlc-agent-launch.yml`](.github/workflows/aidlc-agent-launch.yml)** — **`issues.labeled`** (`aidlc_work:unstarted`) launches the Cursor Cloud Agent against the phase read from Projects v2. **[`aidlc-board-label-sync.yml`](.github/workflows/aidlc-board-label-sync.yml)** — optional **`workflow_dispatch`** / **`repository_dispatch`** to apply **`aidlc_work:unstarted`** after a board move ([docs/github-queue.md](docs/github-queue.md)). **[`aidlc-phase-advance.yml`](.github/workflows/aidlc-phase-advance.yml)** — on merged phase PRs, advances board + label. |
 
-**Notes:** Uses GitHub Projects v2 (personal account — `projects_v2_item` events are org-only so the trigger is `issues.labeled` instead). To start automation: move the board card to the target phase column, then apply `aidlc_work:unstarted` to the issue. The Cursor agent clears `aidlc_work:in_progress` when done via `$AIDLC_GH_CALLBACK_TOKEN` (set in Cursor Cloud Agents dashboard, not in this repo). Do **not** commit tokens. See [docs/github-queue.md](docs/github-queue.md) for full setup.
+**Notes:** GitHub Actions does **not** support **`on: projects_v2_item`**; org webhooks emit **`projects_v2_item`** per [official payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item). Cursor agents clear **`aidlc_work:in_progress`** via **`$AIDLC_GH_CALLBACK_TOKEN`** (Cursor dashboard only — never commit). See [docs/github-queue.md](docs/github-queue.md).
 
 ## GitHub queue
 

--- a/RecipeApp/docker-compose.override.yml
+++ b/RecipeApp/docker-compose.override.yml
@@ -1,4 +1,0 @@
-services:
-  website:
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development

--- a/RecipeApp/docker-compose.yml
+++ b/RecipeApp/docker-compose.yml
@@ -45,9 +45,8 @@ services:
     command: sh -c "npm install && npm run dev -- --host"
     depends_on:
       - recipeapi
-    environment:
-      VITE_USE_EMULATOR: 'true'
-      VITE_API_URL: 'http://localhost:8081'
+    env_file:
+      - ./frontend/.env.emulator
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/RecipeApp/frontend/.env.emulator
+++ b/RecipeApp/frontend/.env.emulator
@@ -1,0 +1,8 @@
+# Safe to commit — emulator-only placeholders (not production Firebase credentials).
+# Used by docker compose for local dev against the Firebase emulator suite.
+VITE_USE_EMULATOR=true
+VITE_API_URL=http://localhost:8081
+VITE_FIREBASE_API_KEY=emulator-not-a-real-key
+VITE_FIREBASE_AUTH_DOMAIN=queen-of-code.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=queen-of-code
+VITE_FIREBASE_APP_ID=emulator-not-a-real-app-id

--- a/RecipeApp/frontend/.env.local.example
+++ b/RecipeApp/frontend/.env.local.example
@@ -1,7 +1,8 @@
-# Copy this file to .env.local for local development (never commit .env.local)
+# Copy to .env.local for non-Docker local dev, or production Firebase Hosting builds.
+# Never commit .env.local. Use real values from the Firebase console only when needed.
 VITE_USE_EMULATOR=true
 VITE_API_URL=http://localhost:8081
-VITE_FIREBASE_API_KEY=AIzaSyBVd8sCrZ9jirMVicyvy5pBcl42JBrEDeI
+VITE_FIREBASE_API_KEY=your-firebase-api-key
 VITE_FIREBASE_AUTH_DOMAIN=queen-of-code.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=queen-of-code
-VITE_FIREBASE_APP_ID=1:367855466316:web:da30996c9878ed98ec01e9
+VITE_FIREBASE_APP_ID=your-firebase-app-id

--- a/docs/github-queue.md
+++ b/docs/github-queue.md
@@ -1,7 +1,8 @@
 # GitHub Issues + Projects v2 (AIDLC automation)
 
 Work is tracked on a **GitHub Projects v2** board with an **"AIDLC phase"** single-select field.
-Automation is **event-driven** — no cron. An agent launches the moment you signal readiness.
+
+**`aidlc_work:unstarted`** is what wakes **`issues.labeled`** → [`aidlc-agent-launch.yml`](../.github/workflows/aidlc-agent-launch.yml). You get that label by: applying it on the issue manually; running **[`aidlc-board-label-sync.yml`](#apply-unstarted-label-event-driven)** once per board move (no polling); letting **[`aidlc-phase-advance.yml`](../.github/workflows/aidlc-phase-advance.yml)** apply it after you merge a phase PR; or (organization Projects only) driving **`repository_dispatch`** from a **`projects_v2_item`** webhook relay. Actions does **not** support **`on: projects_v2_item`** in workflow YAML ([gh-aw#25336](https://github.com/github/gh-aw/issues/25336)); webhook availability is [org-only in the official schema](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item).
 
 Board: [AIDLC — alexa-recipe-app (project #6)](https://github.com/users/queen-of-code/projects/6)
 
@@ -14,6 +15,7 @@ Board: [AIDLC — alexa-recipe-app (project #6)](https://github.com/users/queen-
 | Where | Name | Value |
 |-------|------|-------|
 | Repo Settings → Secrets → Actions | `CURSOR_API_KEY` | API key from [cursor.com/dashboard/integrations](https://cursor.com/dashboard/integrations) → **API Keys** |
+| Repo Settings → Secrets → Actions | `AIDLC_PROJECT_PAT` | Personal access token with **`repo`** and **`project`** (read/write). Used by **`aidlc-agent-launch.yml`** and **`aidlc-board-label-sync.yml`** to call GraphQL for your user-owned Projects v2 board (same limitation documented in the agent launch workflow comments). Not the same secret as **`AIDLC_GH_CALLBACK_TOKEN`**. |
 | Repo Settings → Variables → Actions (optional) | `AIDLC_PROJECT_OWNER` | `queen-of-code` |
 | Repo Settings → Variables → Actions (optional) | `AIDLC_PROJECT_NUMBER` | `6` |
 
@@ -74,10 +76,10 @@ Canonical phase definitions: [AIDLC.md](AIDLC.md).
 
 ### Trigger an agent run
 
-1. Move the board card to the target phase column (e.g. **Plan**).
-2. Apply the label **`aidlc_work:unstarted`** to the issue.
+1. Move the board card or set **AIDLC phase** so the issue is in **Plan**, **Design**, **Build**, **Review**, or **Ship**.
+2. Ensure **`aidlc_work:unstarted`** — see **[Apply unstarted label (event-driven)](#apply-unstarted-label-event-driven)** or add the label manually.
 
-That label fires the [`aidlc-launch.yml`](../.github/workflows/aidlc-launch.yml) workflow, which:
+That label fires **`aidlc-agent-launch.yml`**:
 - Reads the current AIDLC phase from the board
 - Swaps the label to `aidlc_work:in_progress`
 - Launches a Cursor Cloud Agent with the right skill prompt
@@ -96,20 +98,54 @@ For **Build** phase the agent auto-creates a PR. Review and merge that PR before
 
 ### Manual trigger
 
-To launch an agent without touching the label (e.g. for testing or re-runs):
+To launch an agent without waiting for labels (e.g. for testing or re-runs):
 
 ```bash
-gh workflow run aidlc-launch.yml \
+gh workflow run aidlc-agent-launch.yml \
   -f issue_number=123 \
   -f phase=plan
 ```
 
 ---
 
-## Why not `project_card` or `projects_v2_item`?
+## Apply unstarted label (event-driven)
 
-- **`project_card`** (Projects classic) — GitHub no longer allows creating classic projects on personal accounts (deprecated late 2023).
-- **`projects_v2_item`** (Projects v2) — only fires for **org-owned** projects. `queen-of-code` is a personal account, so this event never reaches repo Actions.
-- **`issues.labeled`** fires for all repos including personal accounts, making it the correct event-driven trigger here.
+Workflow: **[`aidlc-board-label-sync.yml`](../.github/workflows/aidlc-board-label-sync.yml)** — **`workflow_dispatch`** (input **`issue_number`**) or **`repository_dispatch`** (event type **`apply_aidlc_unstarted_if_actionable`**, **`client_payload.issue_number`**). Each run reads the linked issue’s **AIDLC phase** from Projects v2 via GraphQL; if the phase is actionable (Plan / Design / Build / Review / Ship), clears **`aidlc_work:in_progress`**, applies **`aidlc_work:unstarted`** (no cron, no snapshot file).
 
-This pattern is documented in [AI-DLC/docs/GITHUB-AIDLC-PROJECT.md](https://github.com/queen-of-code/AI-DLC/blob/main/docs/GITHUB-AIDLC-PROJECT.md) as the personal-account path.
+Patterns:
+
+### After moving a card (manual or script)
+
+```bash
+gh workflow run aidlc-board-label-sync.yml -f issue_number=123
+```
+
+### From automation (`repository_dispatch`)
+
+Uses a PAT with permission for **[repository dispatch events](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event)**:
+
+```bash
+curl -L -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GH_TOKEN_FOR_DISPATCH" \
+  https://api.github.com/repos/queen-of-code/alexa-recipe-app/dispatches \
+  -d '{"event_type":"apply_aidlc_unstarted_if_actionable","client_payload":{"issue_number":123}}'
+```
+
+### Organization Projects + webhook
+
+GitHub delivers **`projects_v2_item`** to **organization webhooks** ([availability](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item)), not **`on:` Actions triggers**. Middleware can forward **`POST /repos/{owner}/{repo}/dispatches`** so each field edit becomes one dispatch — that is genuinely event-driven.
+
+### Merge path (already wired)
+
+**[`aidlc-phase-advance.yml`](../.github/workflows/aidlc-phase-advance.yml)** updates the board **and** **`aidlc_work:unstarted`** when you merge an AIDLC phase PR.
+
+---
+
+## Why not native Project events in Actions?
+
+- **`projects_v2_item` workflow trigger** — invalid YAML today ([discussion](https://github.com/github/gh-aw/issues/25336)).
+- **`project_card`** — classic Projects only ([docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#project_card)).
+- **`issues.labeled`** — reliable launcher once **`aidlc_work:unstarted`** exists.
+
+Further context: **[AI-DLC GitHub+AIDLC queue doc](https://github.com/queen-of-code/AI-DLC/blob/main/docs/GITHUB-AIDLC-PROJECT.md)** · template **[aidlc-board-label-sync.yml](https://github.com/queen-of-code/AI-DLC/blob/main/docs/templates/github-workflows/aidlc-board-label-sync.yml)**.


### PR DESCRIPTION
## Summary

- **Docker Compose works on a fresh clone** — removes the stale `website` override that broke `docker compose` commands; frontend loads committed `frontend/.env.emulator` placeholders so the app renders without checking in real Firebase keys.
- **Secrets hygiene** — `.env.local.example` uses placeholders; emulator-safe values live in checked-in `.env.emulator` only.
- **AI-DLC submodule** — bumps to `8877bbe` (v1.0.0).
- **Automation docs** — updates `AGENTS.md` and `docs/github-queue.md`; adds `aidlc-board-label-sync.yml` workflow for event-driven `aidlc_work:unstarted` labeling.

## Fresh clone test plan

- [ ] `git clone` repo and `cd alexa-recipe-app/RecipeApp`
- [ ] `docker compose up --build` (no env file copy, no `TAG`, no docker secrets)
- [ ] Open http://localhost:5173 — home page renders (not blank)
- [ ] API health at http://localhost:8081/health returns 200
- [ ] Firebase Emulator UI at http://localhost:4000 loads
- [ ] `docker compose stop` succeeds without compose project errors


Made with [Cursor](https://cursor.com)